### PR TITLE
Add CI workflow for typecheck and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: npx tsc --noEmit
+
+      - run: pnpm test


### PR DESCRIPTION
## What

- Add a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on push to `main` and on every pull request:
  - Installs deps with `pnpm install --frozen-lockfile`.
  - Typechecks with `tsc --noEmit`.
  - Runs the vitest suite with `pnpm test`.
- The repo had no CI configured - PR #5's signed-command layer added a full test suite and a `tsc` build gate, but nothing enforced either on PRs. This wires both in so the upcoming BLE/router work is gated on green CI instead of relying on local runs.
